### PR TITLE
adding mutable-content flag

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -8,6 +8,7 @@ type HttpMessage struct {
 	CollapseKey           string        `json:"collapse_key,omitempty"`
 	Priority              string        `json:"priority,omitempty"`
 	ContentAvailable      bool          `json:"content_available,omitempty"`
+	MutableContent        bool          `json:"mutable_content,omitempty"`
 	TimeToLive            *uint         `json:"time_to_live,omitempty"`
 	RestrictedPackageName string        `json:"restricted_package_name,omitempty"`
 	DryRun                bool          `json:"dry_run,omitempty"`


### PR DESCRIPTION
As of iOS 10, there is an optional "mutable-content" boolean flag that can be included in push notifications. This flag must be set to true in order for iOS devices to modify the way the push notification can be presented: https://firebase.google.com/docs/cloud-messaging/http-server-ref#mutable_content.